### PR TITLE
Handle 404s

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -74,6 +74,7 @@ func prettyPrintJSON(b []byte) error {
 	var out bytes.Buffer
 	err := json.Indent(&out, b, "", "\t")
 	if err != nil {
+		level.Debug(logger).Log("msg", "failed indent", "json", b)
 		return fmt.Errorf("indent JSON %w", err)
 	}
 

--- a/pkg/config/request.go
+++ b/pkg/config/request.go
@@ -39,6 +39,10 @@ func DoMetricsGetReq(ctx context.Context, logger log.Logger, endpoint string) ([
 		return nil, fmt.Errorf("reading response body: %w", err)
 	}
 
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s response: %q", resp.Status, b)
+	}
+
 	return b, nil
 }
 


### PR DESCRIPTION
Better reporting for the "Error: indent JSON invalid character 'p' after top-level value" case discussed in https://github.com/observatorium/obsctl/issues/14
