### PR TITLE
Correct Errorf() format strings

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -75,7 +75,7 @@ func prettyPrintJSON(b []byte, w io.Writer) error {
 	var out bytes.Buffer
 	err := json.Indent(&out, b, "", "\t")
 	if err != nil {
-		level.Debug(logger).Log("msg", "failed indent", "json", b)
+		level.Debug(logger).Log("msg", "failed indent", "json", string(b))
 		return fmt.Errorf("indent JSON %w", err)
 	}
 

--- a/pkg/cmd/metrics.go
+++ b/pkg/cmd/metrics.go
@@ -52,7 +52,7 @@ func NewMetricsGetCmd(ctx context.Context) *cobra.Command {
 			if resp.StatusCode()/100 != 2 {
 				if len(resp.Body) != 0 {
 					if perr := prettyPrintJSON(resp.Body, cmd.OutOrStdout()); perr != nil {
-						return fmt.Errorf("request failed with statuscode %d pretty printing: %v", perr, resp.StatusCode())
+						return fmt.Errorf("request failed with statuscode %d pretty printing: %v", resp.StatusCode(), perr)
 					}
 					return fmt.Errorf("request failed with statuscode %d", resp.StatusCode())
 				}
@@ -103,7 +103,7 @@ func NewMetricsGetCmd(ctx context.Context) *cobra.Command {
 			if resp.StatusCode()/100 != 2 {
 				if len(resp.Body) != 0 {
 					if perr := prettyPrintJSON(resp.Body, cmd.OutOrStdout()); perr != nil {
-						return fmt.Errorf("request failed with statuscode %d pretty printing: %v", perr, resp.StatusCode())
+						return fmt.Errorf("request failed with statuscode %d pretty printing: %v", resp.StatusCode(), perr)
 					}
 					return fmt.Errorf("request failed with statuscode %d", resp.StatusCode())
 				}
@@ -150,7 +150,7 @@ func NewMetricsGetCmd(ctx context.Context) *cobra.Command {
 			if resp.StatusCode()/100 != 2 {
 				if len(resp.Body) != 0 {
 					if perr := prettyPrintJSON(resp.Body, cmd.OutOrStdout()); perr != nil {
-						return fmt.Errorf("request failed with statuscode %d pretty printing: %v", perr, resp.StatusCode())
+						return fmt.Errorf("request failed with statuscode %d pretty printing: %v", resp.StatusCode(), perr)
 					}
 					return fmt.Errorf("request failed with statuscode %d", resp.StatusCode())
 				}
@@ -203,7 +203,7 @@ func NewMetricsGetCmd(ctx context.Context) *cobra.Command {
 			if resp.StatusCode()/100 != 2 {
 				if len(resp.Body) != 0 {
 					if perr := prettyPrintJSON(resp.Body, cmd.OutOrStdout()); perr != nil {
-						return fmt.Errorf("request failed with statuscode %d pretty printing: %v", perr, resp.StatusCode())
+						return fmt.Errorf("request failed with statuscode %d pretty printing: %v", resp.StatusCode(), perr)
 					}
 					return fmt.Errorf("request failed with statuscode %d", resp.StatusCode())
 				}
@@ -344,7 +344,7 @@ func NewMetricsQueryCmd(ctx context.Context) *cobra.Command {
 				if resp.StatusCode()/100 != 2 {
 					if len(resp.Body) != 0 {
 						if perr := prettyPrintJSON(resp.Body, cmd.OutOrStdout()); perr != nil {
-							return fmt.Errorf("request failed with statuscode %d pretty printing: %v", perr, resp.StatusCode())
+							return fmt.Errorf("request failed with statuscode %d pretty printing: %v", resp.StatusCode(), perr)
 						}
 						return fmt.Errorf("request failed with statuscode %d", resp.StatusCode())
 					}
@@ -368,7 +368,7 @@ func NewMetricsQueryCmd(ctx context.Context) *cobra.Command {
 				if resp.StatusCode()/100 != 2 {
 					if len(resp.Body) != 0 {
 						if perr := prettyPrintJSON(resp.Body, cmd.OutOrStdout()); perr != nil {
-							return fmt.Errorf("request failed with statuscode %d pretty printing: %v", perr, resp.StatusCode())
+							return fmt.Errorf("request failed with statuscode %d pretty printing: %v", resp.StatusCode(), perr)
 						}
 						return fmt.Errorf("request failed with statuscode %d", resp.StatusCode())
 					}


### PR DESCRIPTION
Resolves https://github.com/observatorium/obsctl/issues/19

This is a minimal PR.  It is possible we could make the output even better by not attempting to parse JSON if we don't get a 200 response.  For this PR I am just trying to get clean output that reveals the problem.

- We fix the invalid `fmt.Errorf()` arguments
- We convert []byte to string when logging.

I had really hoped to fix `make lint` to detect this problem so that it doesn't recur.  There seems to be a problem with the Golang linter and `return xxxf()` with bogus args.  _lint_ happily complained, but never on `return` lines.

I convert non-JSON []byte to string so that the error looks correct when `--log.format=json`.  (If we pass bytes, the JSON logger will base64 encode them.)

Unrelated, @saswatamcode can you tell me the rationale for `$(call require_clean_work_tree,"detected not clean master before running lint")`?  It made lint testing difficult.