### PR TITLE
Log HTTP requests to Observatorium at debug level

### DIFF
--- a/pkg/fetcher/request.go
+++ b/pkg/fetcher/request.go
@@ -3,8 +3,10 @@ package fetcher
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/observatorium/api/client"
 	"github.com/observatorium/api/client/parameters"
 	"github.com/observatorium/obsctl/pkg/config"
@@ -25,7 +27,13 @@ func NewCustomFetcher(ctx context.Context, logger log.Logger) (*client.ClientWit
 	fc, err := client.NewClientWithResponses(cfg.APIs[cfg.Current.API].URL, func(f *client.Client) error {
 		f.Client = c
 		return nil
-	})
+	}, client.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
+		level.Debug(logger).Log(
+			"method", req.Method,
+			"URL", req.URL,
+		)
+		return nil
+	}))
 	if err != nil {
 		return nil, "", fmt.Errorf("getting fetcher client: %w", err)
 	}


### PR DESCRIPTION
I found it difficult to understand what _obsctl_ was doing.

This PR adds debug output to obsctl.  To try it do `obsctl metrics get rules --log.level=debug` and see it now logs "debug: GET: https://observatorium.api.stage.openshift.com/api/metrics/v1/rhobs/api/v1/rules".

Headers are not logged, just the method and URL.