### PR TITLE
Bump obsctl version to `v0.1.0-rc.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ go install github.com/observatorium/obsctl@latest
 or via [bingo](https://github.com/bwplotka/bingo) if you want to pin it,
 
 ```bash
-bingo get -u github.com/observatorium/obsctl
+bingo get -u github.com/observatorium/obsctl@latest
 ```
 
 ## Usage

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version returns 'obsctl' version.
-const Version = "v0.1.0-dev"
+const Version = "v0.1.0-rc.0"


### PR DESCRIPTION
This PR bumps the version of obsctl to `v0.1.0-rc.0` as we plan to release an initial version of it. cc: @matej-g