### PR TITLE
Add rm context command

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Global Flags:
 Use "obsctl context [command] --help" for more information about a command.
 ```
 
+You can also remove a context by using `obsctl context rm <API Name>/<Tenant Name>`. In case an API configuration does not have a tenant associated to it, the API configuration can be removed using `obsctl context api rm <API Name>`.
+
 ### Metrics
 
 You can use `obsctl metrics` to get/set metrics-based resources.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Global Flags:
 Use "obsctl context [command] --help" for more information about a command.
 ```
 
-You can also remove a context by using `obsctl context rm <API Name>/<Tenant Name>`. In case an API configuration does not have a tenant associated to it, the API configuration can be removed using `obsctl context api rm <API Name>`.
+You can also remove a context by using `obsctl context rm <API Name>/<Tenant Name>`. In case an API configuration does not have a tenant associated with it, the API configuration can be removed using `obsctl context api rm <API Name>`.
 
 ### Metrics
 

--- a/README.md
+++ b/README.md
@@ -127,9 +127,10 @@ Usage:
   obsctl context [command]
 
 Available Commands:
-  api         Add/edit API configuration.
+  api         Add/edit/remove API configuration.
   current     View current context configuration.
   list        View all context configuration.
+  rm          Remove context configuration.
   switch      Switch to another context.
 
 Flags:

--- a/pkg/cmd/context.go
+++ b/pkg/cmd/context.go
@@ -19,8 +19,8 @@ func NewContextCommand(ctx context.Context) *cobra.Command {
 
 	apiCmd := &cobra.Command{
 		Use:   "api",
-		Short: "Add/edit API configuration.",
-		Long:  "Add/edit API configuration.",
+		Short: "Add/edit/remove API configuration.",
+		Long:  "Add/edit/remove API configuration.",
 	}
 
 	var addURL, addName string
@@ -136,10 +136,31 @@ func NewContextCommand(ctx context.Context) *cobra.Command {
 		},
 	}
 
+	rmCmd := &cobra.Command{
+		Use:   "rm <api>/<tenant>",
+		Short: "Remove context configuration.",
+		Long:  "Remove context configuration.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cntxt := strings.Split(args[0], "/")
+			if len(cntxt) != 2 {
+				return fmt.Errorf("invalid context name: use format <api>/<tenant>")
+			}
+
+			conf, err := config.Read(logger)
+			if err != nil {
+				return err
+			}
+
+			return conf.RemoveContext(logger, cntxt[0], cntxt[1])
+		},
+	}
+
 	cmd.AddCommand(apiCmd)
 	cmd.AddCommand(switchCmd)
 	cmd.AddCommand(currentCmd)
 	cmd.AddCommand(listCmd)
+	cmd.AddCommand(rmCmd)
 
 	apiCmd.AddCommand(apiAddCmd)
 	apiCmd.AddCommand(apiRmCmd)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -364,9 +364,10 @@ func (c *Config) SetCurrentContext(logger log.Logger, api string, tenant string)
 	return c.Save(logger)
 }
 
-// RemoveContext removes the specified context <api>/<tenant>. If the API has only one tenant, API is removed.
+// RemoveContext removes the specified context <api>/<tenant>. If the API configuration has only one tenant,
+// the API configuration is removed.
 func (c *Config) RemoveContext(logger log.Logger, api string, tenant string) error {
-	// If there is only one tenant for the API, remove the whole API.
+	// If there is only one tenant per API configuration, remove the whole API configuration.
 	if _, ok := c.APIs[api].Contexts[tenant]; ok {
 		if len(c.APIs[api].Contexts) == 1 {
 			return c.RemoveAPI(logger, api)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -363,3 +363,15 @@ func (c *Config) SetCurrentContext(logger log.Logger, api string, tenant string)
 
 	return c.Save(logger)
 }
+
+// RemoveContext removes the specified context <api>/<tenant>. If the API has only one tenant, API is removed.
+func (c *Config) RemoveContext(logger log.Logger, api string, tenant string) error {
+	// If there is only one tenant for the API, remove the whole API.
+	if _, ok := c.APIs[api].Contexts[tenant]; ok {
+		if len(c.APIs[api].Contexts) == 1 {
+			return c.RemoveAPI(logger, api)
+		}
+	}
+
+	return c.RemoveTenant(logger, tenant, api)
+}


### PR DESCRIPTION
I thought would be nice to have a command that removes the context, without the need to individually remove tenant and/or api.
This PR adds the following behavior:

- `obsctl context rm <api>/<tenant>` is the command
- It removes a tenant from an api. If the api has only one tenant, the whole api is removed
- It sees context as the relation between api+tenant. If an api does not have a tenant, the `rm` command cannot be used. The command `obsctl context api rm <api>` can be used though.

If we agree on this behavior, I'd then add tests + update docs :)
It partially implements https://github.com/observatorium/obsctl/issues/23

Signed-off-by: Jéssica Lins <jessicaalins@gmail.com>