### PR TITLE
Initial trace query command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Available Commands:
   login       Login as a tenant. Will also save tenant details locally.
   logout      Logout a tenant. Will remove locally saved details.
   metrics     Metrics based operations for Observatorium.
+  traces      Trace-based operations for Observatorium.
 
 Flags:
   -h, --help                help for obsctl

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -63,6 +63,7 @@ func NewObsctlCmd(ctx context.Context) *cobra.Command {
 	cmd.AddCommand(NewContextCommand(ctx))
 	cmd.AddCommand(NewLoginCmd(ctx))
 	cmd.AddCommand(NewLogoutCmd(ctx))
+	cmd.AddCommand(NewTracesCmd(ctx))
 
 	cmd.PersistentFlags().StringVar(&logLevel, "log.level", "info", "Log filtering level.")
 	cmd.PersistentFlags().StringVar(&logFormat, "log.format", logFormatCLILog, "Log format to use.")

--- a/pkg/cmd/traces.go
+++ b/pkg/cmd/traces.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/go-kit/log/level"
+	"github.com/observatorium/obsctl/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+func NewTraceServicesCmd(ctx context.Context) *cobra.Command {
+	var outputFormat string
+	cmd := &cobra.Command{
+		Use:   "services",
+		Short: "The names of services with trace information",
+		Long:  "The names of services with trace information",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Read(logger)
+			if err != nil {
+				return fmt.Errorf("getting reading config: %w", err)
+			}
+
+			client, err := cfg.Client(ctx, logger)
+			if err != nil {
+				return fmt.Errorf("getting current client: %w", err)
+			}
+
+			level.Debug(logger).Log(
+				"msg", "Using configuration",
+				"URL", cfg.APIs[cfg.Current.API].URL,
+				"tenant", cfg.Current.Tenant)
+
+			url := fmt.Sprintf("%s%s", cfg.APIs[cfg.Current.API].URL, "api/traces/v1/rhobs/api/services")
+			resp, err := client.Get(url)
+			if err != nil {
+				return fmt.Errorf("getting: %w", err)
+			}
+			bodyBytes, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return fmt.Errorf("getting: %w", err)
+			}
+			if resp.StatusCode >= 300 {
+				fmt.Fprintf(os.Stdout, "%d: %s\n%s", resp.StatusCode, resp.Status, string(bodyBytes))
+				return fmt.Errorf("%d: %s", resp.StatusCode, resp.Status)
+			}
+
+			if outputFormat == "table" {
+				return printTable(bodyBytes)
+			} else if outputFormat == "json" {
+				fmt.Printf("%s\n", string(bodyBytes))
+			} else {
+				return fmt.Errorf("unknown format %s", outputFormat)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "Output format. One of: json|table")
+
+	return cmd
+}
+
+func NewTracesCmd(ctx context.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "traces",
+		Short: "Trace-based operations for Observatorium.",
+		Long:  "Trace-based operations for Observatorium.",
+	}
+
+	cmd.AddCommand(NewTraceServicesCmd(ctx))
+
+	return cmd
+}
+
+func printTable(js []byte) error {
+	var result map[string]interface{}
+	err := json.Unmarshal(js, &result)
+	if err != nil {
+		return err
+	}
+	data, ok := result["data"]
+	if !ok {
+		return fmt.Errorf("no JSON data in %s", string(js))
+	}
+	services, ok := data.([]interface{})
+	if !ok {
+		return fmt.Errorf("expected JSON list in %s", string(js))
+	}
+	for _, svc := range services {
+		fmt.Printf("%s\n", svc)
+	}
+	return nil
+}

--- a/pkg/cmd/traces.go
+++ b/pkg/cmd/traces.go
@@ -56,7 +56,7 @@ func NewTraceServicesCmd(ctx context.Context) *cobra.Command {
 				}
 				_ = printTable(cmd.OutOrStdout(), cmd.OutOrStderr(), svcs)
 			} else if outputFormat == "json" {
-				prettyPrintJSON(bodyBytes, cmd.OutOrStdout())
+				return prettyPrintJSON(bodyBytes, cmd.OutOrStdout())
 			} else {
 				return fmt.Errorf("unknown format %s", outputFormat)
 			}


### PR DESCRIPTION
Signed-off-by: Ed Snible <snible@us.ibm.com>

Initial implementation of `obsctl traces services`.

If Observatorium has tracing enabled, and query is enabled, and the user has rights, the output will be a list of the services that are traced.

cc @pavolloffay