### PR TITLE
Proof-of-concept: e2e tests that work on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ lint: $(FAILLINT) $(GOLANGCI_LINT) $(MISSPELL) build format docs check-git deps
 test-e2e:
 	@rm -rf ./test/e2e/e2e_*
 	@rm -rf ./test/e2e/tmp
+	@kill -9 `pidof hydra` || true # (If the previous test failed, it may not clean up)
 	@./test/e2e/start_hydra.sh
 	@go test -v -timeout 99m github.com/observatorium/obsctl/test/e2e
 	@kill -9 `pidof hydra`

--- a/test/e2e/osx-hydra.yaml
+++ b/test/e2e/osx-hydra.yaml
@@ -1,0 +1,5 @@
+strategies:
+  access_token: jwt
+urls:
+  self:
+    issuer: http://host.docker.internal:4444/

--- a/test/e2e/start_hydra.sh
+++ b/test/e2e/start_hydra.sh
@@ -9,9 +9,11 @@ OS="$(uname)"
 case $OS in
 'Linux')
     HYDRA_OS='linux'
+    HYDRA_CONFIG='hydra.yaml'
     ;;
 'Darwin')
     HYDRA_OS='macos'
+    HYDRA_CONFIG='osx-hydra.yaml'
     ;;
 *)
     echo "Unsupported OS for this script: $OS"
@@ -29,7 +31,7 @@ gethydra() {
 }
 
 startHydra() {
-    (DSN=memory $WD/test/e2e/tmp/bin/hydra serve all --dangerous-force-http --config $WD/test/e2e/hydra.yaml &>/dev/null) &
+    (DSN=memory $WD/test/e2e/tmp/bin/hydra serve all --dangerous-force-http --config $WD/test/e2e/$HYDRA_CONFIG &>/dev/null) &
     echo "-------------------------------------------"
     echo "- Waiting for Hydra to come up...  -"
     echo "-------------------------------------------"


### PR DESCRIPTION
Signed-off-by: Ed Snible <snible@us.ibm.com>

This PR is an exercise to size the amount of work to get the e2e tests working on a Mac.

The work is incomplete.  To finish the work the hack to get the token in the tests must be put into the non-test code that gets the token.  (That seems like a bad idea.)

The basic problem is that on the Mac, for a container (such as Hydra) to talk to a process running on the Mac the container must use `host.docker.internal` as the host.  This host doesn't exist on non-OSX Docker.  Furthermore, because this is a security setup, Hydra must know the host the clients will use to talk to it -- and that value is different when the client is running in a sibling container.

This was somewhat handled in the Observatorium-API tests (which use Dex rather than Thanos.). It is handled there by custom code to create _tenants.yaml_.  For _obsctl_ we may need something to deal with the config file URLs.