### PR TITLE
Traces: Fix JSON pretty print

### DIFF
--- a/pkg/cmd/traces.go
+++ b/pkg/cmd/traces.go
@@ -74,7 +74,11 @@ func NewTraceServicesCmd(ctx context.Context) *cobra.Command {
 					fmt.Fprintln(cmd.OutOrStdout(), svc)
 				}
 			case "json":
-				return prettyPrintJSON(bodyBytes, cmd.OutOrStdout())
+				json, err := prettyPrintJSON(bodyBytes)
+				if err != nil {
+					return fmt.Errorf("failed to pretty print JSON: %s", err)
+				}
+				fmt.Fprintln(cmd.OutOrStdout(), json)
 			default:
 				cmd.SilenceUsage = false
 				return fmt.Errorf("unknown format %s", outputFormat)


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

Somehow changes for pretty printing JSON and traces command introduction caused a mixed up which has not been detected by CI / conflict warning.

This PR fixes currently failing build.