### PR TITLE
Workaround for efficientgo/e2e dependency issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,3 +38,6 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+// workaround for https://github.com/efficientgo/e2e/issues/41 to make obsctl build
+replace github.com/efficientgo/tools/core v0.0.0-20210129205121-421d0828c9a6 => github.com/efficientgo/tools/core v0.0.0-20210731122119-5d4a0645ce9a

--- a/go.sum
+++ b/go.sum
@@ -383,7 +383,6 @@ github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaB
 github.com/efficientgo/e2e v0.11.1/go.mod h1:vDnF4AAEZmO0mvyFIATeDJPFaSRM7ywaOnKd61zaSoE=
 github.com/efficientgo/e2e v0.12.0 h1:cT5pBSCyXQtdLWCCs6/4RQVAN4FoKyIZ0ePnvI5EpiM=
 github.com/efficientgo/e2e v0.12.0/go.mod h1:xDHUyIqAWyVWU29Lf+BaZoavW7xAbDEvTwHWWI/3bhk=
-github.com/efficientgo/tools/core v0.0.0-20210129205121-421d0828c9a6/go.mod h1:OmVcnJopJL8d3X3sSXTiypGoUSgFq1aDGmlrdi9dn/M=
 github.com/efficientgo/tools/core v0.0.0-20210201224146-3d78f4d30648/go.mod h1:cFZoHUhKg31xkPnPjhPKFtevnx0Xcg67ptBRxbpaxtk=
 github.com/efficientgo/tools/core v0.0.0-20210609125236-d73259166f20/go.mod h1:OmVcnJopJL8d3X3sSXTiypGoUSgFq1aDGmlrdi9dn/M=
 github.com/efficientgo/tools/core v0.0.0-20210731122119-5d4a0645ce9a h1:Az9zRvQubUIHE+tHAm0gG7Dwge08V8Q/9uNSIFjFm+A=


### PR DESCRIPTION
There's an issue with one of the dependencies that makes obsctl not build out of the box (details: efficientgo/e2e#41). This change is a workaround for the upstream issue until that gets fixed and trickles down to obsctl.