### PR TITLE
feat: make oidc scopes configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Flags:
       --oidc.client-id string       The OIDC client ID, see https://tools.ietf.org/html/rfc6749#section-2.3.
       --oidc.client-secret string   The OIDC client secret, see https://tools.ietf.org/html/rfc6749#section-2.3.
       --oidc.issuer-url string      The OIDC issuer URL, see https://openid.net/specs/openid-connect-discovery-1_0.html#IssuerDiscovery.
-      --oidc.scopes strings         Optional scopes, must contain 'openid', see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest (default [openid,offline_access])
+      --oidc.scopes strings         Optional scopes, see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest (default [offline_access])
       --tenant string               The name of the tenant.
 
 Global Flags:

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Flags:
       --oidc.client-id string       The OIDC client ID, see https://tools.ietf.org/html/rfc6749#section-2.3.
       --oidc.client-secret string   The OIDC client secret, see https://tools.ietf.org/html/rfc6749#section-2.3.
       --oidc.issuer-url string      The OIDC issuer URL, see https://openid.net/specs/openid-connect-discovery-1_0.html#IssuerDiscovery.
+      --oidc.scopes strings         Optional scopes, must contain 'openid', see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest (default [openid,offline_access])
       --tenant string               The name of the tenant.
 
 Global Flags:

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Flags:
       --oidc.client-id string       The OIDC client ID, see https://tools.ietf.org/html/rfc6749#section-2.3.
       --oidc.client-secret string   The OIDC client secret, see https://tools.ietf.org/html/rfc6749#section-2.3.
       --oidc.issuer-url string      The OIDC issuer URL, see https://openid.net/specs/openid-connect-discovery-1_0.html#IssuerDiscovery.
-      --oidc.scopes strings         Optional scopes, see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest (default [offline_access])
+      --oidc.offline-access         If set to false, oidc scope offline_access will not be requested, see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest (default true)
       --tenant string               The name of the tenant.
 
 Global Flags:

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -51,7 +51,7 @@ func NewLoginCmd(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVar(&tenantCfg.OIDC.ClientSecret, "oidc.client-secret", "", "The OIDC client secret, see https://tools.ietf.org/html/rfc6749#section-2.3.")
 	cmd.Flags().StringVar(&tenantCfg.OIDC.ClientID, "oidc.client-id", "", "The OIDC client ID, see https://tools.ietf.org/html/rfc6749#section-2.3.")
 	cmd.Flags().StringVar(&tenantCfg.OIDC.Audience, "oidc.audience", "", "The audience for whom the access token is intended, see https://openid.net/specs/openid-connect-core-1_0.html#IDToken.")
-	cmd.Flags().StringSliceVar(&tenantCfg.OIDC.Scopes, "oidc.scopes", []string{"offline_access"}, "Optional scopes, see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest")
+	cmd.Flags().BoolVar(&tenantCfg.OIDC.OfflineAccess, "oidc.offline-access", true, "If set to false, oidc scope offline_access will not be requested, see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest")
 
 	cmd.Flags().BoolVar(&disableOIDCCheck, "disable.oidc-check", false, "If set to true, OIDC flags will not be checked while saving tenant details locally.")
 

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -51,6 +51,7 @@ func NewLoginCmd(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVar(&tenantCfg.OIDC.ClientSecret, "oidc.client-secret", "", "The OIDC client secret, see https://tools.ietf.org/html/rfc6749#section-2.3.")
 	cmd.Flags().StringVar(&tenantCfg.OIDC.ClientID, "oidc.client-id", "", "The OIDC client ID, see https://tools.ietf.org/html/rfc6749#section-2.3.")
 	cmd.Flags().StringVar(&tenantCfg.OIDC.Audience, "oidc.audience", "", "The audience for whom the access token is intended, see https://openid.net/specs/openid-connect-core-1_0.html#IDToken.")
+	cmd.Flags().StringSliceVar(&tenantCfg.OIDC.Scopes, "oidc.scopes", []string{"openid", "offline_access"}, "Optional scopes, must contain 'openid', see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest")
 
 	cmd.Flags().BoolVar(&disableOIDCCheck, "disable.oidc-check", false, "If set to true, OIDC flags will not be checked while saving tenant details locally.")
 

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -51,7 +51,7 @@ func NewLoginCmd(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVar(&tenantCfg.OIDC.ClientSecret, "oidc.client-secret", "", "The OIDC client secret, see https://tools.ietf.org/html/rfc6749#section-2.3.")
 	cmd.Flags().StringVar(&tenantCfg.OIDC.ClientID, "oidc.client-id", "", "The OIDC client ID, see https://tools.ietf.org/html/rfc6749#section-2.3.")
 	cmd.Flags().StringVar(&tenantCfg.OIDC.Audience, "oidc.audience", "", "The audience for whom the access token is intended, see https://openid.net/specs/openid-connect-core-1_0.html#IDToken.")
-	cmd.Flags().StringSliceVar(&tenantCfg.OIDC.Scopes, "oidc.scopes", []string{"openid", "offline_access"}, "Optional scopes, must contain 'openid', see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest")
+	cmd.Flags().StringSliceVar(&tenantCfg.OIDC.Scopes, "oidc.scopes", []string{"offline_access"}, "Optional scopes, see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest")
 
 	cmd.Flags().BoolVar(&disableOIDCCheck, "disable.oidc-check", false, "If set to true, OIDC flags will not be checked while saving tenant details locally.")
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -78,11 +78,11 @@ type TenantConfig struct {
 type OIDCConfig struct {
 	Token *oauth2.Token `json:"token"`
 
-	Audience     string   `json:"audience"`
-	ClientID     string   `json:"clientID"`
-	ClientSecret string   `json:"clientSecret"`
-	IssuerURL    string   `json:"issuerURL"`
-	Scopes       []string `json:"scopes"`
+	Audience      string `json:"audience"`
+	ClientID      string `json:"clientID"`
+	ClientSecret  string `json:"clientSecret"`
+	IssuerURL     string `json:"issuerURL"`
+	OfflineAccess bool   `json:"offlineAccess"`
 }
 
 // Client returns a OAuth2 HTTP client based on the configuration for a tenant.
@@ -93,13 +93,17 @@ func (t *TenantConfig) Client(ctx context.Context, logger log.Logger) (*http.Cli
 			return nil, fmt.Errorf("constructing oidc provider: %w", err)
 		}
 
-		t.OIDC.Scopes = append(t.OIDC.Scopes, "openid")
+		scopes := []string{"openid"}
+
+		if t.OIDC.OfflineAccess {
+			scopes = append(scopes, "offline_access")
+		}
 
 		ccc := clientcredentials.Config{
 			ClientID:     t.OIDC.ClientID,
 			ClientSecret: t.OIDC.ClientSecret,
 			TokenURL:     provider.Endpoint().TokenURL,
-			Scopes:       t.OIDC.Scopes,
+			Scopes:       scopes,
 		}
 
 		if t.OIDC.Audience != "" {
@@ -141,13 +145,17 @@ func (t *TenantConfig) Transport(ctx context.Context, logger log.Logger) (http.R
 			return nil, fmt.Errorf("constructing oidc provider: %w", err)
 		}
 
-		t.OIDC.Scopes = append(t.OIDC.Scopes, "openid")
+		scopes := []string{"openid"}
+
+		if t.OIDC.OfflineAccess {
+			scopes = append(scopes, "offline_access")
+		}
 
 		ccc := clientcredentials.Config{
 			ClientID:     t.OIDC.ClientID,
 			ClientSecret: t.OIDC.ClientSecret,
 			TokenURL:     provider.Endpoint().TokenURL,
-			Scopes:       t.OIDC.Scopes,
+			Scopes:       scopes,
 		}
 
 		if t.OIDC.Audience != "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -78,10 +78,11 @@ type TenantConfig struct {
 type OIDCConfig struct {
 	Token *oauth2.Token `json:"token"`
 
-	Audience     string `json:"audience"`
-	ClientID     string `json:"clientID"`
-	ClientSecret string `json:"clientSecret"`
-	IssuerURL    string `json:"issuerURL"`
+	Audience     string   `json:"audience"`
+	ClientID     string   `json:"clientID"`
+	ClientSecret string   `json:"clientSecret"`
+	IssuerURL    string   `json:"issuerURL"`
+	Scopes       []string `json:"scopes"`
 }
 
 // Client returns a OAuth2 HTTP client based on the configuration for a tenant.
@@ -96,7 +97,7 @@ func (t *TenantConfig) Client(ctx context.Context, logger log.Logger) (*http.Cli
 			ClientID:     t.OIDC.ClientID,
 			ClientSecret: t.OIDC.ClientSecret,
 			TokenURL:     provider.Endpoint().TokenURL,
-			Scopes:       []string{"openid", "offline_access"},
+			Scopes:       t.OIDC.Scopes,
 		}
 
 		if t.OIDC.Audience != "" {
@@ -142,7 +143,7 @@ func (t *TenantConfig) Transport(ctx context.Context, logger log.Logger) (http.R
 			ClientID:     t.OIDC.ClientID,
 			ClientSecret: t.OIDC.ClientSecret,
 			TokenURL:     provider.Endpoint().TokenURL,
-			Scopes:       []string{"openid", "offline_access"},
+			Scopes:       t.OIDC.Scopes,
 		}
 
 		if t.OIDC.Audience != "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -93,6 +93,8 @@ func (t *TenantConfig) Client(ctx context.Context, logger log.Logger) (*http.Cli
 			return nil, fmt.Errorf("constructing oidc provider: %w", err)
 		}
 
+		t.OIDC.Scopes = append(t.OIDC.Scopes, "openid")
+
 		ccc := clientcredentials.Config{
 			ClientID:     t.OIDC.ClientID,
 			ClientSecret: t.OIDC.ClientSecret,
@@ -138,6 +140,8 @@ func (t *TenantConfig) Transport(ctx context.Context, logger log.Logger) (http.R
 		if err != nil {
 			return nil, fmt.Errorf("constructing oidc provider: %w", err)
 		}
+
+		t.OIDC.Scopes = append(t.OIDC.Scopes, "openid")
 
 		ccc := clientcredentials.Config{
 			ClientID:     t.OIDC.ClientID,


### PR DESCRIPTION
Small change to make the scopes that are requested during login configurable per new flag 'oidc.scopes'.

Why:  Service accounts without offline_access capabilities are unable to log in due to requesting offline_access without permissions. With this override one can omit 'offline_access' if required.

I kept the hardcoded values 'openid' and 'offline_access' as defaults on the flag to not introduce any breaking changes.